### PR TITLE
Sync estonia-public-sources recipes from kodaniku-kratt (2026-07-24)

### DIFF
--- a/skills/estonia-public-sources/.claude-plugin/plugin.json
+++ b/skills/estonia-public-sources/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "estonia-public-sources",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Route Estonian public-data questions to documented official APIs, downloads, and reproducible public web interfaces. Use for Estonian statistics, legislation, parliament, registries, public finance, procurement, environment, health, transport, municipal records, and other official data retrieval.",
   "author": {
     "name": "Taivo Marketplace"

--- a/skills/estonia-public-sources/SKILL.md
+++ b/skills/estonia-public-sources/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   distribution:
     publish_anthropic: true
     plugin_name: estonia-public-sources
-    plugin_version: 1.4.0
+    plugin_version: 1.5.0
     plugin_author: Taivo Marketplace
 ---
 

--- a/skills/estonia-public-sources/sources/business-register-open-data/SKILL.md
+++ b/skills/estonia-public-sources/sources/business-register-open-data/SKILL.md
@@ -1,15 +1,106 @@
 ---
 name: business-register-open-data
-description: Download Estonian Business Register snapshots for legal entities, registry cards, persons, shareholders, beneficial owners, and related company records.
+description: Look up an Estonian company's registry code, status, and address by name, or download bulk Business Register snapshots (entities, shareholders, beneficial owners).
 ---
 
 # Business Register Open Data
 
-## Access
+## Single-company lookup by name (preferred for one registry code)
 
-Public ZIP snapshots from `https://avaandmed.ariregister.rik.ee/en/downloading-open-data`. No login. Send a normal user agent if Cloudflare returns 403.
+For a single company's registry code (`registrikood`), status, or address — do NOT
+download a bulk snapshot. Use the public autocomplete JSON the search UI calls. No
+authentication, returns JSON directly, works with any user agent.
 
-## Retrieve
+```text
+GET https://ariregister.rik.ee/est/api/autocomplete?q=Bolt+Technology&company=true
+```
+
+- `q` is a name substring (URL-encoded). `company=true` restricts to legal entities.
+- Response: `{ "status": "OK", "data": [ { "reg_code", "name", "historical_names",
+  "status", "legal_address", "zip_code", "legal_form", "url", "company_id" }, ... ] }`.
+- `status` is a registry status code (`R` = registered/active).
+- `historical_names` lets you match a company that was renamed (e.g. "Taxify OÜ" →
+  "Bolt Technology OÜ").
+- Match the exact name against `name` (or `historical_names`); if several rows
+  come back, do not blindly take the first — pick the one whose name matches.
+
+The `/est/api/autocomplete` path works and returns JSON. Do NOT use the bare
+`/api/autocomplete` path — it returns a Cloudflare error page.
+
+### Anti-fabrication grounding rule (issue #16)
+
+A registry code is an identifier, not something to recall. State a registry code
+ONLY if it appears verbatim in output your script actually printed from this
+endpoint. If the lookup returns an empty `data` array, an error, or you cannot
+match the requested company, say the code could not be retrieved — NEVER supply a
+registry code from memory or guess an 8-digit number. (Observed failure: the agent
+confidently answered fabricated codes like 14036220 / 14532842 for Bolt Technology
+OÜ; the real code is 12417834, which this endpoint returns.)
+
+### Worked run_code script (registry code + tax-arrears, verified 2026-07-24)
+
+This resolves the registry code, then chains into the EMTA public tax-arrears query
+(see `tax-public-inquiries`). The tax-arrears form needs a cookie + CSRF token, so
+that half uses raw `fetch` (the `get` helper does not expose response headers);
+`get` is fine for the autocomplete lookup.
+
+```js
+import { get, show, sleep } from "./kratt.mjs";
+
+const name = "Bolt Technology"; // company name (substring is fine)
+
+// 1. Registry code via the autocomplete JSON.
+const ac = await get(
+  "https://ariregister.rik.ee/est/api/autocomplete?q=" +
+    encodeURIComponent(name) + "&company=true"
+);
+const rows = ac.data ?? [];
+const hit =
+  rows.find((c) => (c.name || "").toLowerCase().startsWith(name.toLowerCase())) ??
+  rows[0];
+if (!hit) {
+  show("NO MATCH — registry code could not be retrieved for: " + name);
+} else {
+  const regCode = String(hit.reg_code);
+  show({ regCode, status: hit.status, name: hit.name, address: hit.legal_address });
+
+  // 2. Tax arrears: GET form (capture SAQUSESSION cookie + CSRFToken), then POST.
+  const formRes = await fetch("https://apps.emta.ee/saqu/public/taxdebt?lang=en");
+  const cookie = (formRes.headers.getSetCookie()[0] || "").split(";")[0];
+  const formHtml = await formRes.text();
+  const token = /name="CSRFToken"\s+value="([^"]+)"/.exec(formHtml)?.[1];
+
+  const body = new URLSearchParams({
+    personCode: regCode,
+    p_submit: "Search",
+    CSRFToken: token,
+  });
+  const debtRes = await fetch("https://apps.emta.ee/saqu/public/taxdebt/query", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded", Cookie: cookie },
+    body: body.toString(),
+  });
+  const debtText = (await debtRes.text())
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  show("TAX ARREARS (HTTP " + debtRes.status + "): " + debtText.slice(0, 400));
+}
+```
+
+Verified live 2026-07-24: autocomplete for "Bolt Technology" returns
+`reg_code: 12417834`, `name: "Bolt Technology OÜ"`, `status: "R"`,
+`historical_names: ["Taxify OÜ", "MTAKSO OÜ"]`; the EMTA query then prints
+"Person Bolt Technology OÜ (12417834) has no arrears as of <timestamp>". Report the
+arrears status only from that printed line, with its timestamp — a no-arrears result
+is point-in-time, not proof arrears never existed.
+
+## Bulk snapshots (many companies / fields not in autocomplete)
+
+Public ZIP snapshots from `https://avaandmed.ariregister.rik.ee/en/downloading-open-data`.
+No login. Send a normal user agent if Cloudflare returns 403. Use these only when you
+need bulk data or fields the autocomplete does not carry (shareholders, beneficial
+owners, registry-card detail) — not for a single company's registry code.
 
 1. Fetch the download page and select the dataset family and format.
 2. Resolve relative links against `https://avaandmed.ariregister.rik.ee`.
@@ -25,7 +116,10 @@ Other published families include `yldandmed`, `registrikaardid`, `kaardile_kantu
 
 ## Return
 
-Preserve source filename, snapshot/retrieval date, registry code (`ariregistri_kood` where present), legal form and status, registration dates, names, addresses, and source-specific relationship fields. Keep beneficial-owner and person records separate from core entity records.
+Preserve registry code (`reg_code`/`ariregistri_kood`), legal form and status,
+name and historical names, address, source, and retrieval time. For bulk snapshots
+also keep the source filename and snapshot date. Keep beneficial-owner and person
+records separate from core entity records.
 
 ## Limits
 
@@ -35,4 +129,8 @@ Preserve source filename, snapshot/retrieval date, registry code (`ariregistri_k
 
 ## Verify
 
-Require HTTP 200, `application/zip`, ZIP magic bytes `PK`, and a valid archive member. For the simple CSV snapshot, require a header containing the registry identifier before analysis.
+- Autocomplete: require HTTP 200 JSON with `status: "OK"` and a `data` array; a
+  usable result has a numeric `reg_code` and a `name` matching the requested company.
+- Bulk: require HTTP 200, `application/zip`, ZIP magic bytes `PK`, and a valid archive
+  member; for the simple CSV snapshot require a header containing the registry
+  identifier before analysis.

--- a/skills/estonia-public-sources/sources/election-results-data/SKILL.md
+++ b/skills/estonia-public-sources/sources/election-results-data/SKILL.md
@@ -25,6 +25,8 @@ Public ZIP/XML election snapshots and public decision pages. No authentication. 
 
 Known archive: `https://www.valimised.ee/sites/default/files/uploads/misc/RK2019_election_result_data.zip`.
 
+The ZIP pattern does not exist for 2023+ elections (`RK2023_election_result_data.zip` returns 404). For elections from 2021 on, use the year-specific result site's JSON API (verified 2026-07-24): `https://<code><year>.valimised.ee/resources/<page-type>/data.json`, e.g. `https://rk2023.valimised.ee/resources/election-result/data.json` for party-level results. `GET /resources/metadata.json` on the same host identifies the election (`electionCode`, `electionType`, `electionYear`) — confirmed for `rk2023`, `ep2024`, and `kov2025`.
+
 ## Return
 
 Keep dataset type (`results` or `vvk_decisions`), election type/year, geography and candidate/list identifiers, vote/result fields, decision title/date, direct record URL, legal reference, archive member name, and retrieval time.
@@ -37,4 +39,4 @@ Keep dataset type (`results` or `vvk_decisions`), election type/year, geography 
 
 ## Verify
 
-Require a valid ZIP and XML members matching the selected election. The RK2019 archive contains `RK2019_ELECTION_RESULT_*.xml` plus county and parish result files. Reject HTML error pages even if the requested filename ends in `.zip`.
+Require a valid ZIP and XML members matching the selected election. The RK2019 archive contains `RK2019_ELECTION_RESULT_*.xml` plus county and parish result files. Reject HTML error pages even if the requested filename ends in `.zip`. For the JSON API, require valid JSON whose `metadata.json` election code matches the requested election before reporting results.

--- a/skills/estonia-public-sources/sources/legal-acts-data/SKILL.md
+++ b/skills/estonia-public-sources/sources/legal-acts-data/SKILL.md
@@ -40,3 +40,83 @@ Preserve legal IDs, title, type, issuer, validity start/end, publication status,
 ## Verify
 
 Require HTTP 200 JSON, `staatus: OK`, integer pagination metadata, and a parseable `aktid` array. At least one returned act must contain `globaalID`, `pealkiri`, `kehtivus`, and `url` before reporting success.
+
+## Contract drift warning (verified 2026-07-24)
+
+Resolving act representations like `/akt/{id}.xml` against `https://www.riigiteataja.ee` now returns the HTML application shell (SPA), NOT the act text — regardless of Accept header. Do not treat that HTML as act content, and do NOT recite paragraph (§) text from memory as if it were fetched.
+
+Working text endpoints (verified 2026-07-24):
+
+- `GET https://www.riigiteataja.ee/public-api/api/v1/akt/{globaalID}` — act metadata JSON.
+- `GET https://www.riigiteataja.ee/public-api/api/v1/akt/{globaalID}/blob-html` — full consolidated act HTML. Responses can exceed 500 KB and the endpoint ignores Range headers, so a truncating `http_request` (20k) only returns the head; fetch and filter it inside the `run_code` sandbox instead.
+
+If those endpoints are unavailable, ground answers in the search API's metadata only (title, validity, status, act URL), summarize at that level, and link the act for the user to read the text.
+
+## Weak-model workflow: worked run_code script (added 2026-07-24, issue #8)
+
+`pealkiri=` search matches substrings AND returns one `aktid` row per historical redaction, so a title search for e.g. "Töölepingu seadus" returns dozens of rows sharing the exact title, each a different consolidated-text version with its own `kehtivus.algus`/`lopp`. Do not just take the first search hit. To find the version actually in force:
+
+1. Filter `aktid` to rows whose `pealkiri` equals the searched title exactly (not a substring match).
+2. Among those, keep rows where `kehtivus.algus <= today` and (`kehtivus.lopp` is null or `>= today`).
+3. Sort by `kehtivus.algus` descending and fetch `/public-api/api/v1/akt/{globaalID}` for each, starting with the highest `algus`, until one has top-level `aktiStaatus === "KEHTIV"` — that is the authoritative in-force signal. (A field named `kehtivId` exists on the metadata response but was observed always equal to the requested `globaalID` itself in testing 2026-07-24 — it did NOT point to a different, more-current globaalID. Do not rely on it; use `aktiStaatus` instead.)
+
+Then fetch `blob-html` for that `globaalID`, `save()` it (it can exceed 500 KB), and locate sections by scanning for `§ <n>` or a keyword with `indexOf`, printing a window of characters around each hit — HTML tags included, so strip them for readability. A single keyword match is not guaranteed to be the right section (e.g. "maksimaalne" appears once in Perehüvitiste seadus but for an unrelated elatisabi clause) — print several hits and let the surrounding heading text (`§ NN. <title>`) disambiguate, or search a more specific phrase (benefit ceilings: search "ülempiir", not "maksimaalne").
+
+State numeric values, multipliers, and deadlines ONLY if their exact wording appears in a window you printed — if the printed window cuts off before the operative words, print a wider window instead of completing the sentence from memory (observed failure: § 40 located, but the model answered "kolmekordne" from memory while the fetched text says "kahekordne").
+
+```js
+import { get, show, save, sleep } from "./kratt.mjs";
+
+async function getRetry(url) {
+  try {
+    return await get(url);
+  } catch (e) {
+    if (!String(e).includes("429")) throw e;
+    await sleep(2000);
+    return await get(url); // one retry, then let it throw
+  }
+}
+
+async function fetchCurrentAct(title) {
+  const q = encodeURIComponent(title);
+  const search = await getRetry(`https://www.riigiteataja.ee/api/oigusakt_otsing/1/otsi?leht=1&limiit=200&pealkiri=${q}`);
+  const today = new Date().toISOString().slice(0, 10);
+  const exact = (search.aktid ?? []).filter(a => a.pealkiri === title);
+  if (exact.length === 0) throw new Error(`No exact title match for "${title}"`);
+  const candidates = exact
+    .filter(a => (a.kehtivus.algus ?? "") <= today && (a.kehtivus.lopp === null || a.kehtivus.lopp >= today))
+    .sort((a, b) => b.kehtivus.algus.localeCompare(a.kehtivus.algus));
+  for (const c of candidates) {
+    const meta = await getRetry(`https://www.riigiteataja.ee/public-api/api/v1/akt/${c.globaalID}`);
+    if (meta.aktiStaatus === "KEHTIV") return { globaalID: c.globaalID, meta };
+  }
+  if (candidates.length === 0) throw new Error(`No currently-dated redaction for "${title}"`);
+  const fallback = candidates[0]; // best guess if none confirmed KEHTIV
+  return { globaalID: fallback.globaalID, meta: await getRetry(`https://www.riigiteataja.ee/public-api/api/v1/akt/${fallback.globaalID}`) };
+}
+
+function findAround(html, term, max = 3) {
+  const hits = [];
+  let idx = -1;
+  while (hits.length < max && (idx = html.indexOf(term, idx + 1)) !== -1) {
+    hits.push(html.slice(Math.max(0, idx - 400), idx + 400).replace(/<[^>]+>/g, " ").replace(/\s+/g, " "));
+  }
+  return hits;
+}
+
+const { globaalID, meta } = await fetchCurrentAct("Töölepingu seadus"); // example verified 2026-07-24: globaalID 103072026034
+show({ globaalID, aktiStaatus: meta.aktiStaatus, algus: meta.aktiParameetrid.kehtivuseAlgus, lopp: meta.aktiParameetrid.kehtivuseLopp });
+
+const html = await getRetry(`https://www.riigiteataja.ee/public-api/api/v1/akt/${globaalID}/blob-html`);
+await save(`akt_${globaalID}.html`, html); // reuse in later run_code calls with load() instead of refetching
+show(`saved ${html.length} chars as akt_${globaalID}.html`);
+
+for (const hit of findAround(html, "§ 97")) show(hit, 500);
+for (const hit of findAround(html, "etteteatamise")) show(hit, 500);
+```
+
+Later run_code calls in the same question should `load("akt_{globaalID}.html")` to re-slice for a different section instead of refetching the ~550 KB blob.
+
+Verified live 2026-07-24 (plain `node -e` fetch chain, no sandbox):
+- "Töölepingu seadus" → currently valid `globaalID: 103072026034` (`aktiStaatus: "KEHTIV"`, in force 2026-07-13..2026-09-30). `blob-html` (550,960 chars) contains `§ 97. Tööandja ülesütlemise etteteatamise tähtajad` and the string "etteteatamise" (multiple hits).
+- "Perehüvitiste seadus" → currently valid `globaalID: 121052026010` (`aktiStaatus: "KEHTIV"`, in force 2026-05-22..2026-08-31). `blob-html` (335,756 chars) contains `§ 40. Vanemahüvitise ülempiir`, found by searching "ülempiir" (15 hits) or "vanemahüvitis" (202 hits, so prefer the narrower term); searching "maksimaalne" alone finds only an unrelated elatisabi clause (§ 50(4)), not the parental-benefit cap — a reminder to check the heading around a hit, not just the raw string match.

--- a/skills/estonia-public-sources/sources/planning-decisions/SKILL.md
+++ b/skills/estonia-public-sources/sources/planning-decisions/SKILL.md
@@ -33,8 +33,86 @@ Return at least `sysid`, `planid`, name, type, status, organizing authority, pur
 ## Limits
 
 - Status is lifecycle data. Keep the original `planseisNimi` or `klPlanseisByPlanseis`, and do not collapse draft, established, repealed, or paused plans.
-- Search/export request bodies support more UI filters, but use only fields verified from the live application; use `otsistring` unless another exact filter contract has been checked.
+- Search/export request bodies support more UI filters, but use only fields verified from the live application; use `otsistring` unless another exact filter contract has been checked (probed 2026-07: an `orgId` body filter is silently ignored).
 - Document links may be PDF, ASiC-E, or another original file type.
+- The national register cannot answer Tallinn public-display questions. `planeering/otsing` has no working organizing-authority filter (`{"orgId":784}` returns the same unfiltered `totalElements` as an empty body — silently ignored), and `planseis`/`planseisNimi` only ever takes coarse post-establishment values (`broneeritud`, `kehtiv`, `osaliselt kehtiv`, `osaliselt peatunud`, `kehtetu`) — there is no in-process "avalik väljapanek" value and the detail response exposes only milestone dates, no display-window start/end. For live Tallinn public displays and freshly initiated plans, use the Tallinn register below instead.
+
+## Tallinn: Tallinna planeeringute register (tpr.tallinn.ee)
+
+Tallinn's own register gets new detail plans first, and — unlike the national register — it exposes the in-process public-display window that is the citizen's objection window. The SPA lives at `https://tpr.tallinn.ee/`; its backend under `https://tpr.tallinn.ee/api/*` answers **anonymously today** on the read endpoints below (only the edit/menetlus routes are Bearer-gated). Verified live 2026-07-24.
+
+Caveat: these endpoints are `withCredentials`-flagged in the SPA but currently respond without any token or cookie. If they start returning HTTP 401 `WWW-Authenticate: Bearer`, the anonymous access has been closed — re-verify and fall back to citing `https://tpr.tallinn.ee/` as a pointer rather than inventing data.
+
+Anonymous read endpoints:
+
+- `GET https://tpr.tallinn.ee/api/avalikustamine/avaleht` — JSON array of current & upcoming public displays / discussions (front-page "avalikustamised"). This is the direct answer to "what is on public display in Tallinn right now." Each row:
+  - `avLiikNimetus` — `Avalik väljapanek` / `Eskiislahenduse avalik väljapanek` / `Avalik arutelu`.
+  - `staatus` — `TOIMUB` (ongoing) or `TULEMAS` (upcoming).
+  - `alustamiseAeg` / `lopetamiseAeg` — display window = the citizen objection window (`lopetamiseAeg` is null for `Avalik arutelu` rows, which are single meetings).
+  - `toimumiskoht`, `linnaosa`, `planLiikNimetus`, `planKood`, `planNimetus`.
+- `POST https://tpr.tallinn.ee/api/detailplaneering/otsi?page=0&size=25` with a JSON body — Spring page of detail plans (`content`, `size`, `totalElements`, `totalPages`, `number`). Rows carry `planKood`, `planNimetus`, `seisund`, `seisundNimetus`, `seisundiKp`, `linnaosa`. Body contract fields: `isKiirotsing`, `searchText`, `locationText`, `personText`, `personId`, `archiveNumber`, `statusCode`, `startDate`, `endDate`, `tagAktiivesMenetluses`, `tagKehtivPlaneering`, `tagYldMuutev`, `tagTapsustavPt`, `tagKhsKoostamine`, `sortKey`, `sortDirection`. Empty `{}` returns everything (~4589 rows); `statusCode` filters to one process stage; `locationText` matches streets/districts; `sortKey: "seisundiKp"` + `sortDirection: "desc"` surfaces the most recent stage changes first.
+- `GET https://tpr.tallinn.ee/api/classifiers/menseisund/dp/menetluses` — the `statusCode` vocabulary (detail plans in process): `3203` Algatamisel, `3208` Eskiis avalikustamisel, `3211` Koostamisel, `3221` Avalikustamisel, `3226` Kehtestamisel, `3231` Kehtetuks tunnistamisel.
+- Supporting: `GET https://tpr.tallinn.ee/api/planeering/kiirotsing?searchText=X` (quick text search), `GET https://tpr.tallinn.ee/api/detailplaneering/linnaosad/valikud` (district picklist), `GET https://tpr.tallinn.ee/api/config`.
+
+Grounding rule: state plan names, `planKood`s, addresses, and display-window dates ONLY when they appear in output you actually printed from these endpoints — never from memory or inference. If a fetch fails, say so and link the register; do not fabricate a plausible-looking listing.
+
+### Weak-model workflow: worked run_code script (added 2026-07-24, issue #17)
+
+Answers "Millised detailplaneeringud on Tallinnas praegu avalikul väljapanekul või hiljuti algatatud?" in two requests. The `get` helper takes a second `init` argument, so POST is `get(url, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) })`.
+
+```js
+import { get, show, save, sleep } from "./kratt.mjs";
+
+async function getRetry(url, init) {
+  try {
+    return await get(url, init);
+  } catch (e) {
+    if (!String(e).includes("429")) throw e;
+    await sleep(2000);
+    return await get(url, init); // one retry, then let it throw
+  }
+}
+
+// 1) Current + upcoming public displays (the citizen objection windows).
+const av = await getRetry("https://tpr.tallinn.ee/api/avalikustamine/avaleht");
+const displays = av
+  .filter(r => r.planLiikNimetus === "Detailplaneering")
+  .map(r => ({
+    plan: r.planNimetus,
+    kood: r.planKood,
+    liik: r.avLiikNimetus,
+    staatus: r.staatus, // TOIMUB / TULEMAS
+    algus: r.alustamiseAeg?.slice(0, 10),
+    lopp: r.lopetamiseAeg?.slice(0, 10) ?? null, // null for Avalik arutelu
+    linnaosa: r.linnaosa,
+    koht: r.toimumiskoht,
+  }));
+
+// 2) Recently initiated plans (statusCode 3203 = Algatamisel), newest first.
+const page = await getRetry(
+  "https://tpr.tallinn.ee/api/detailplaneering/otsi?page=0&size=25",
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      isKiirotsing: false,
+      statusCode: 3203,
+      sortKey: "seisundiKp",
+      sortDirection: "desc",
+    }),
+  },
+);
+const initiated = (page.content ?? []).map(r => ({
+  plan: r.planNimetus,
+  kood: r.planKood,
+  seisund: r.seisundNimetus, // "Algatamisel"
+  kuupaev: r.seisundiKp,
+  linnaosa: r.linnaosa,
+}));
+
+await save("tallinn_dp.json", { displays, initiated }); // later calls can load() instead of refetching
+show({ avalikulValjapanekul: displays, hiljutiAlgatatud: initiated }, 3500);
+```
 
 ## Verify
 

--- a/skills/estonia-public-sources/sources/riigikogu-open-data/SKILL.md
+++ b/skills/estonia-public-sources/sources/riigikogu-open-data/SKILL.md
@@ -17,6 +17,7 @@ description: Query the Riigikogu open data API for draft laws, votes, members, a
 - Draft search: `https://api.riigikogu.ee/api/volumes/drafts?initiatedStartDate=2026-01-01&initiatedEndDate=2026-01-31&lang=EN&page=0&size=20`
 - Draft detail: `https://api.riigikogu.ee/api/volumes/drafts/{uuid}?lang=EN&querySteno=false`
 - Votes: `https://api.riigikogu.ee/api/votings?startDate=2025-01-01&endDate=2025-01-31&lang=EN`
+- One member's votes (with each decision inline): `https://api.riigikogu.ee/api/votings/plenary-member/{memberUuid}?startDate=2026-05-01&endDate=2026-06-30&lang=ET&size=100&page=0`
 - Plenary agendas: `https://api.riigikogu.ee/api/agenda/plenary?startDate=2025-01-01&endDate=2025-01-31&lang=EN`
 - Stenograms: `https://api.riigikogu.ee/api/steno/verbatims?startDate=2025-01-01&endDate=2025-01-31`
 - Public calendar fallback: https://www.riigikogu.ee/tegevus/kalender/
@@ -58,3 +59,83 @@ description: Query the Riigikogu open data API for draft laws, votes, members, a
 - For the agenda example, require each sitting to contain `uuid`, `sittingDateTime`, and `agendaItems`.
 - Confirm returned dates overlap the requested window.
 - Treat HTTP 429 as rate limiting, not evidence that the endpoint is unavailable.
+
+## Weak-model workflow notes (added 2026-07-24, issue #8; member-votings rewrite issue #15)
+
+- The API rate-limits aggressively: on HTTP 429 or an HTML error page, back off and retry the SAME request before changing approach.
+- **Voting history for one member: use `/api/votings/plenary-member/{memberUuid}`.** It returns that member's votings paged, each row already carrying the member's `decision` (poolt/vastu/erapooletu/ei hääletanud/puudub) plus the `relatedDraft` title and mark. This means **no per-voting `/api/votings/{uuid}` detail fetch** — the old N+1 fan-out was what spiralled into 429s. The whole answer is 2–3 requests total: one `/api/plenary-members` list to resolve the UUID by name, then one page (100 votings) — a second page only if the window has 100+ votings.
+- Notes on this endpoint: it ignores `sort`, returning votings oldest→newest; page with a hard cap and, when truncating, keep the LAST pages (most recent votings). `_embedded.content` holds the rows; `page.totalPages`/`page.totalElements` drive paging. `type.value === "Kohaloleku kontroll"` rows are presence checks, not substantive votes.
+- Keep a single 429-retry budget for the whole run so a rate-limited run degrades to a partial answer (with an explicit "(osaline — API piiras päringute arvu)" note) instead of retrying to the step cap. `save()` intermediate pages so a later run_code call can `load()` instead of refetching.
+
+```js
+import { get, show, save, load, sleep } from "./kratt.mjs";
+
+// One shared 429-retry budget for the whole run. When it's spent, stop retrying
+// and answer from what we already have — never spiral to the step cap (issue #15).
+let retryBudget = 5;
+async function getBudgeted(url) {
+  let delay = 1500;
+  for (;;) {
+    try {
+      return await get(url);
+    } catch (e) {
+      if (!String(e).includes("429") || retryBudget <= 0) throw e;
+      retryBudget--;
+      await sleep(delay);
+      delay = Math.min(delay * 2, 12000); // adaptive backoff
+    }
+  }
+}
+
+const NAME = "Ees Nimi";
+const startDate = "2026-05-24", endDate = "2026-07-24";
+
+// 1) Resolve the member UUID by name — one request. The list is ~400 KB but a
+//    single fetch; filter in code, never print it whole.
+const members = await getBudgeted("https://api.riigikogu.ee/api/plenary-members?lang=ET");
+const member = members.find((m) => m.fullName === NAME);
+if (!member) throw new Error("member not found: " + NAME);
+
+// 2) Fetch the member's OWN voting history directly — decisions are inline, so
+//    there is NO per-voting detail fetch. Page with a hard cap; the API returns
+//    votings oldest→newest and ignores `sort`, so when the cap truncates we keep
+//    the LAST pages (most recent votings).
+const base = "https://api.riigikogu.ee/api/votings/plenary-member/" + member.uuid;
+const pageUrl = (p) => `${base}?startDate=${startDate}&endDate=${endDate}&lang=ET&size=100&page=${p}`;
+const MAX_PAGES = 3; // hard cap: up to 300 votings, ample for "last couple months"
+
+const first = await getBudgeted(pageUrl(0));
+const totalPages = first?.page?.totalPages ?? 1;
+let wanted = Array.from({ length: totalPages }, (_, i) => i);
+let truncated = false;
+if (wanted.length > MAX_PAGES) { wanted = wanted.slice(-MAX_PAGES); truncated = true; }
+
+const byPage = { 0: first };
+for (const p of wanted) {
+  if (byPage[p]) continue;
+  try { byPage[p] = await getBudgeted(pageUrl(p)); }
+  catch { truncated = true; break; } // rate-limited out — keep what we have
+}
+
+const rows = [];
+for (const p of wanted) {
+  for (const v of byPage[p]?._embedded?.content ?? []) {
+    rows.push({
+      date: v.startDateTime?.slice(0, 10),
+      type: v.type?.value,
+      decision: v.decision?.value,
+      title: v.description,
+      draft: v.relatedDraft ? `${v.relatedDraft.title} (${v.relatedDraft.mark})` : null,
+    });
+  }
+}
+rows.reverse(); // newest first for display
+
+await save("member_votings.json", { member: member.fullName, startDate, endDate, truncated, rows });
+
+// Presence checks ("Kohaloleku kontroll") are noise; substantive votes are the answer.
+const substantive = rows.filter((r) => r.type !== "Kohaloleku kontroll");
+show({ member: member.fullName, window: [startDate, endDate], total: rows.length, substantive: substantive.length, truncated }, 400);
+show(substantive.slice(0, 25));
+// If truncated is true, tell the user the answer is partial (oldest votes omitted).
+```

--- a/skills/estonia-public-sources/sources/statistics-api/SKILL.md
+++ b/skills/estonia-public-sources/sources/statistics-api/SKILL.md
@@ -29,6 +29,11 @@ Public PXWeb JSON API. No authentication. Use `https://andmed.stat.ee/api/v1/en/
 
 Working sample: `GET https://andmed.stat.ee/api/v1/en/stat/IA001`, then POST the payload above. The response is JSON-stat 2 with table ID `IA001`, year `2025`, and a numeric `value`.
 
+Known tables (verified 2026-07-24):
+
+- Wages: `PA001` is discontinued (data ends 2022Q4). Annual wage statistics live in `PA101` under `majandus/palk-ja-toojeukulu/palk/aastastatistika` (updated 2026-03).
+- Population totals: `RV021` under `rahvastik/rahvastikunaitajad-ja-koosseis/rahvaarv-ja-rahvastiku-koosseis/RV021.PX`.
+
 ## Return
 
 Preserve the table ID, source and update metadata, dimension codes and labels, selected values, units/decimals, observations, exact POST payload, and retrieval time.
@@ -38,6 +43,8 @@ Preserve the table ID, source and update metadata, dimension codes and labels, s
 - The API root itself returns 404; include the language and database path.
 - Table IDs are not enough to construct a query: always read the current variable contract first.
 - Confirm units, seasonal adjustment, reference period, and suppression markers before analysis.
+- Variable codes may contain non-ASCII characters (e.g. `Vanuserühm` in RV021); send them exactly as returned by the table contract.
+- Discontinued tables still return contracts and data; check the last period value before treating a table as current.
 
 ## Verify
 

--- a/skills/estonia-public-sources/sources/tax-public-inquiries/SKILL.md
+++ b/skills/estonia-public-sources/sources/tax-public-inquiries/SKILL.md
@@ -26,6 +26,40 @@ Use this source for a person's or entity's public EMTA reference number or curre
 
 No CAPTCHA was present in the verified public flow. If the service later introduces one, stop automation instead of bypassing it.
 
+## Worked run_code script (tax arrears, verified 2026-07-24)
+
+The `get` helper does not expose response headers, so it cannot carry the session
+cookie the CSRF check needs — the POST returns `403 Bad or missing CSRF value`
+without the `SAQUSESSION` cookie from the GET. Use raw `fetch` and pass the cookie
+back explicitly. For a company you do not yet have a registry code for, resolve it
+first via `business-register-open-data` (its autocomplete JSON) — never guess it.
+
+```js
+import { show } from "./kratt.mjs";
+
+const personCode = "12417834"; // registry code (or personal ID) — obtained from a source, not memory
+
+// 1. GET the form: capture the SAQUSESSION cookie and the hidden CSRFToken.
+const formRes = await fetch("https://apps.emta.ee/saqu/public/taxdebt?lang=en");
+const cookie = (formRes.headers.getSetCookie()[0] || "").split(";")[0];
+const token = /name="CSRFToken"\s+value="([^"]+)"/.exec(await formRes.text())?.[1];
+
+// 2. POST the query with the SAME cookie + token.
+const res = await fetch("https://apps.emta.ee/saqu/public/taxdebt/query", {
+  method: "POST",
+  headers: { "Content-Type": "application/x-www-form-urlencoded", Cookie: cookie },
+  body: new URLSearchParams({ personCode, p_submit: "Search", CSRFToken: token }).toString(),
+});
+const text = (await res.text()).replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+show("HTTP " + res.status + ": " + text.slice(0, 400));
+```
+
+Verified live 2026-07-24: for `personCode=12417834` this prints "Person Bolt
+Technology OÜ (12417834) has no arrears as of <timestamp>". State the arrears status
+and the identifier ONLY from the line the script printed, quoting its timestamp; if
+the POST is not HTTP 200 or the result text is missing, report that the arrears check
+failed rather than asserting a status.
+
 ## Output and limits
 
 - Keep the queried identifier, endpoint, retrieval time, and exact returned fields or message.


### PR DESCRIPTION
Syncs seven `estonia-public-sources` recipes with the newer versions maintained in [taivop/kodaniku-kratt](https://github.com/taivop/kodaniku-kratt), which had drifted ahead of upstream and would otherwise be lost on the next sync. Fixes taivop/kodaniku-kratt#19.

Each upstream copy was diffed and confirmed **strictly behind** its kodaniku-kratt counterpart (every upstream-only line is a line that the local version reworded/expanded — no independent upstream edits are clobbered).

## Files changed
- `sources/riigikogu-open-data/SKILL.md` — switch member-voting recipe to `/api/votings/plenary-member/{uuid}` (decisions inline, 2–3 requests), removing the old N+1 detail-fetch 429 spiral.
- `sources/business-register-open-data/SKILL.md` — add single-company `/est/api/autocomplete` lookup, an anti-fabrication grounding rule for registry codes, and a worked run_code script chaining into the EMTA tax-arrears query.
- `sources/tax-public-inquiries/SKILL.md` — add a worked run_code script for the EMTA public tax-arrears query (GET form for SAQUSESSION cookie + CSRFToken, then POST).
- `sources/planning-decisions/SKILL.md` — add verified TPR Tallinn endpoints (`avalikustamine/avaleht`, `detailplaneering/otsi`, status vocabulary) plus a worked run_code script.
- `sources/legal-acts-data/SKILL.md` — add Riigi Teataja `blob-html` contract-drift warning and a worked run_code script (fetch/save/slice the >500 KB act HTML) with a "numbers only from printed windows" grounding rule.
- `sources/election-results-data/SKILL.md` — document the year-specific `valimised.ee` JSON API for 2021+ elections (the RK ZIP pattern 404s from 2023 on).
- `sources/statistics-api/SKILL.md` — note known/discontinued tables (`PA001`→`PA101`, `RV021`) and that discontinued tables still return contracts.

## Version bump
Bumps `plugin_version` 1.4.0 → 1.5.0 in both `.claude-plugin/plugin.json` and `SKILL.md`, following the existing convention that recipe content changes bump the plugin version (e.g. #11 went 1.2.0 → 1.4.0).

## Merge ordering — depends on unmerged kodaniku-kratt PRs
Four of these recipes take their content from kodaniku-kratt PRs that are **not yet merged there**. This upstream PR should be merged **together with / after** those, so the two repos stay consistent:
- `riigikogu-open-data` — https://github.com/taivop/kodaniku-kratt/pull/26
- `business-register-open-data` and `tax-public-inquiries` — https://github.com/taivop/kodaniku-kratt/pull/27
- `planning-decisions` — https://github.com/taivop/kodaniku-kratt/pull/28

The remaining three (`legal-acts-data`, `election-results-data`, `statistics-api`) come from kodaniku-kratt `main` and have no such dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
