### PR TITLE
Align coach skill with source document

### DIFF
--- a/skills/coach/.claude-plugin/plugin.json
+++ b/skills/coach/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "coach",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Neutral thinking partner for the user. USE WHEN the user asks for coaching, help with reflection, is struggling to get started or understand a fuzzy topic, wants to talk something through, wants to talk out loud, asks for a Socratic mode, is struggling to phrase a concrete problem or idea, seems emotionally loaded about something, or similar -- or might benefit from a coach'y approach.",
   "author": {
     "name": "Taivo Marketplace"

--- a/skills/coach/SKILL.md
+++ b/skills/coach/SKILL.md
@@ -5,15 +5,13 @@ metadata:
   distribution:
     publish_anthropic: true
     plugin_name: coach
-    plugin_version: 0.1.0
+    plugin_version: 0.1.1
     plugin_author: Taivo Marketplace
 ---
 
 # Coach
 
 Use all the instructions below without referring to them by name. If the user asks, it is fine to explain to them what you are doing and why, without dwelling on it too much and keeping the conversation around the topic at hand.
-
-Keep each reply short and conversational — this is a dialogue, not analysis. Do not produce long reasoning or essays; the user does the thinking.
 
 ## Goal
 


### PR DESCRIPTION
Reconciles `skills/coach/SKILL.md` against the source document the skill was written from.

## Context

The `coach` skill was already added in 74cc116 (pushed directly to `master`, no PR). I diffed the source document against the committed skill sentence-by-sentence: **all of the source content is present**, and the committed version additionally fixed two typos ("one are" → "one area", "comes back" → "come back") and repaired the markdown (the source's nine literal `1.` list entries, and a `<User>:`/`<You>:` dialogue example that HTML-escapes to invisible when rendered). Those fixes are kept.

One line in the committed version had no counterpart in the source:

> Keep each reply short and conversational — this is a dialogue, not analysis. Do not produce long reasoning or essays; the user does the thinking.

This PR removes it. `skills/coach/README.md` already covers the same intent, noting that the skill is meant to be run at low reasoning effort.

## Changes

- `skills/coach/SKILL.md` — remove the reply-length instruction; bump `plugin_version` 0.1.0 → 0.1.1
- `skills/coach/.claude-plugin/plugin.json` — regenerated (version bump only)

`.claude-plugin/marketplace.json` is unchanged, since it does not carry plugin versions and the description was untouched.

## Validation

```
python3 scripts/generate_plugin_manifests.py     # updated skills/coach/.claude-plugin/plugin.json
python3 scripts/generate_marketplace.py          # already up to date
python3 scripts/validate_codex_skills.py         # ok: validated 7 package directories
python3 scripts/validate_anthropic_plugins.py    # ok: validated 7 plugin manifest(s)
python3 scripts/generate_plugin_manifests.py --check   # ok: updated 0
python3 scripts/generate_marketplace.py --check        # ok: already up to date
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmgrfpFWiHE3YLkTAbT9vU


---
_Generated by [Claude Code](https://claude.ai/code/session_01GmgrfpFWiHE3YLkTAbT9vU)_